### PR TITLE
Updated build number to 2

### DIFF
--- a/app.json
+++ b/app.json
@@ -20,14 +20,16 @@
       "**/*"
     ],
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "buildNumber": "2"
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#ebecec"
       },
-      "package": "com.tjcouch.transferablediscipleship"
+      "package": "com.tjcouch.transferablediscipleship",
+      "versionCode": "2"
     },
     "web": {
       "favicon": "./assets/favicon.png",


### PR DESCRIPTION
Apparently we need to update the  build number when creating a new release. This can be [automated](https://docs.expo.dev/build-reference/app-versions/) in the future.