### PR TITLE
Add dist folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 .expo/
+dist/
 gh-pages-staging/app/
 npm-debug.*
 *.jks


### PR DESCRIPTION
Apparently I replaced the `dist` folder with `gh-pages-staging/app`. And apparently `expo update` puts stuff in the `dist` folder. Whoops.